### PR TITLE
Add block-comments /* ... */ to prog syntax

### DIFF
--- a/src/parsing/string_to_program.py
+++ b/src/parsing/string_to_program.py
@@ -1,7 +1,9 @@
 from multiprocessing import Pool
 
 import parsec
-from parsec import generate, string, sepBy, spaces, regex
+from parsec import generate, string, sepBy, regex, many, optional, exclude
+from parsec import spaces as parsec_spaces
+from parsec import any as parsec_any
 
 import config
 from parsing.string_to_ltl_with_predicates import string_to_ltl_with_predicates
@@ -23,7 +25,21 @@ state = regex(r'[a-zA-Z0-9@$_-]+')
 
 
 @generate
+def comment():
+    end_comment = string("*/")
+    yield string("/*")
+    yield many(exclude(parsec_any(), end_comment))
+    yield end_comment
+    return None
+
+
+def spaces():
+    return (parsec_spaces() >> optional(comment) >> parsec_spaces())
+
+
+@generate
 def program_parser():
+    yield spaces()
     yield string("program") >> spaces()
     program_name = yield name << spaces()
     yield string("{") >> spaces()


### PR DESCRIPTION
To add comments, we simply override parsec's whitespace parser. We allow the possibility of a /* followed by any sequence of characters ended by */. Thus, these block comments may now appear whenever the original syntax allowed for whitespace.

We also add a spaces() parser at the head of the main parser, to allow comments (or mere whitespace) at the top of a .prog file.