### PR TITLE
ltlmt: skip sat check for assumptions that contain LTL

### DIFF
--- a/src/parsing/string_to_ltlmt.py
+++ b/src/parsing/string_to_ltlmt.py
@@ -354,7 +354,11 @@ class ToProgram(NodeWalker):
         init_values = [(str(x), types[str(x)], init_type_values(x)) for x in self.vars]
 
         # TODO use this init_assumptions to limit env init transitions
-        if not sat(conjunct_formula_set(init_assumptions), types):
+        try:
+            satisfiable_assumptions = sat(conjunct_formula_set(init_assumptions), types)
+        except NotImplementedError:
+            satisfiable_assumptions = True
+        if not satisfiable_assumptions:
             raise Exception(
                 "Unsatisfiable initial assumptions: "
                 + "\n".join(map(str, init_assumptions))


### PR DESCRIPTION
The LTLMT workflow does a simple check at the beginning: if the assumptions are unsatisfiable, then the specification is vacuously realisable by any controller.

However, if any of the assumptions contain LTL modalities, the sat() check will fail with `NotImplementedError`. In this case, rather than just erroring out, I think we should assume that the assumptions are satisfiable and attempt synthesis.